### PR TITLE
Center blog article content for improved reading experience

### DIFF
--- a/src/scss/components/_article.scss
+++ b/src/scss/components/_article.scss
@@ -4,6 +4,9 @@
 
 .article__header {
   margin-bottom: 30px;
+  max-width: 680px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .article__image-wrapper {
@@ -107,7 +110,7 @@
     margin-bottom: 30px;
   }
 
-  // Optimal reading width (680px) for text content
+  // Optimal reading width (680px) for text content, centered
   > p,
   > ul,
   > ol,
@@ -120,6 +123,8 @@
   > .wp-block-heading,
   > .wp-block-quote {
     max-width: 680px;
+    margin-left: auto;
+    margin-right: auto;
   }
 
   // Allow wider elements (images, tables, embeds, TOC)

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -181,6 +181,9 @@ mix.js( 'src/js/index.js', `${themePath}/assets/index.js` )
                 /^contact_widget/,
                 /^adr$/,
                 /^adress_wrap/,
+
+                /^sidebar/,
+                /^widget-about/,
             ],
 
             // Greedy - only patterns that truly need greedy matching


### PR DESCRIPTION
## Summary
- Centered article header and content blocks (paragraphs, lists, headings, quotes) within 680px optimal reading width
- Added sidebar/widget-about patterns to PurgeCSS safelist

## Test plan
- [ ] Verify article content is horizontally centered on blog posts
- [ ] Verify article header is centered
- [ ] Confirm sidebar and widget-about styles are preserved after production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)